### PR TITLE
Renamed Asset to MainCamera

### DIFF
--- a/Assets/Scenes/scene.unity
+++ b/Assets/Scenes/scene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -40724,7 +40724,12 @@ PrefabInstance:
     - target: {fileID: 9010264696739504857, guid: b2306de44b0abca41918c5bb5c6f198f,
         type: 3}
       propertyPath: m_Name
-      value: Player
+      value: MainCamera
+      objectReference: {fileID: 0}
+    - target: {fileID: 9010264696739504857, guid: b2306de44b0abca41918c5bb5c6f198f,
+        type: 3}
+      propertyPath: m_TagString
+      value: MainCamera
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b2306de44b0abca41918c5bb5c6f198f, type: 3}


### PR DESCRIPTION
Simple name change and assigning the tag MainCamera to the player asset in the game scene.

linked to #32 