### PR TITLE
Pc and mobile controls added

### DIFF
--- a/Assets/Data/PlayerControls.cs
+++ b/Assets/Data/PlayerControls.cs
@@ -46,9 +46,18 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": true
                 },
                 {
-                    ""name"": ""Interact"",
+                    ""name"": ""InteractPC"",
                     ""type"": ""Button"",
                     ""id"": ""10dc3cf2-f27d-4d72-adc9-867f32439735"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""InteractMobile"",
+                    ""type"": ""Button"",
+                    ""id"": ""8a2ae436-f325-46d1-a95d-49a402ce2fe3"",
                     ""expectedControlType"": ""Button"",
                     ""processors"": """",
                     ""interactions"": """",
@@ -199,23 +208,12 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                 },
                 {
                     ""name"": """",
-                    ""id"": ""65405536-edb3-4d2e-a94c-23ce49a32c39"",
-                    ""path"": ""<Touchscreen>/Press"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": ""Mobile"",
-                    ""action"": ""Interact"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": """",
                     ""id"": ""2f3024bc-3a42-438f-9980-ccf1d91841c4"",
                     ""path"": ""<Mouse>/leftButton"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""PC"",
-                    ""action"": ""Interact"",
+                    ""action"": ""InteractPC"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
@@ -227,6 +225,17 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""groups"": ""PC"",
                     ""action"": ""Pause"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""65405536-edb3-4d2e-a94c-23ce49a32c39"",
+                    ""path"": ""<Touchscreen>/Press"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Mobile"",
+                    ""action"": ""InteractMobile"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 }
@@ -557,7 +566,8 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         m_Play = asset.FindActionMap("Play", throwIfNotFound: true);
         m_Play_Movement = m_Play.FindAction("Movement", throwIfNotFound: true);
         m_Play_Look = m_Play.FindAction("Look", throwIfNotFound: true);
-        m_Play_Interact = m_Play.FindAction("Interact", throwIfNotFound: true);
+        m_Play_InteractPC = m_Play.FindAction("InteractPC", throwIfNotFound: true);
+        m_Play_InteractMobile = m_Play.FindAction("InteractMobile", throwIfNotFound: true);
         m_Play_Pause = m_Play.FindAction("Pause", throwIfNotFound: true);
         // UI
         m_UI = asset.FindActionMap("UI", throwIfNotFound: true);
@@ -634,7 +644,8 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
     private List<IPlayActions> m_PlayActionsCallbackInterfaces = new List<IPlayActions>();
     private readonly InputAction m_Play_Movement;
     private readonly InputAction m_Play_Look;
-    private readonly InputAction m_Play_Interact;
+    private readonly InputAction m_Play_InteractPC;
+    private readonly InputAction m_Play_InteractMobile;
     private readonly InputAction m_Play_Pause;
     public struct PlayActions
     {
@@ -642,7 +653,8 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         public PlayActions(@PlayerControls wrapper) { m_Wrapper = wrapper; }
         public InputAction @Movement => m_Wrapper.m_Play_Movement;
         public InputAction @Look => m_Wrapper.m_Play_Look;
-        public InputAction @Interact => m_Wrapper.m_Play_Interact;
+        public InputAction @InteractPC => m_Wrapper.m_Play_InteractPC;
+        public InputAction @InteractMobile => m_Wrapper.m_Play_InteractMobile;
         public InputAction @Pause => m_Wrapper.m_Play_Pause;
         public InputActionMap Get() { return m_Wrapper.m_Play; }
         public void Enable() { Get().Enable(); }
@@ -659,9 +671,12 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
             @Look.started += instance.OnLook;
             @Look.performed += instance.OnLook;
             @Look.canceled += instance.OnLook;
-            @Interact.started += instance.OnInteract;
-            @Interact.performed += instance.OnInteract;
-            @Interact.canceled += instance.OnInteract;
+            @InteractPC.started += instance.OnInteractPC;
+            @InteractPC.performed += instance.OnInteractPC;
+            @InteractPC.canceled += instance.OnInteractPC;
+            @InteractMobile.started += instance.OnInteractMobile;
+            @InteractMobile.performed += instance.OnInteractMobile;
+            @InteractMobile.canceled += instance.OnInteractMobile;
             @Pause.started += instance.OnPause;
             @Pause.performed += instance.OnPause;
             @Pause.canceled += instance.OnPause;
@@ -675,9 +690,12 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
             @Look.started -= instance.OnLook;
             @Look.performed -= instance.OnLook;
             @Look.canceled -= instance.OnLook;
-            @Interact.started -= instance.OnInteract;
-            @Interact.performed -= instance.OnInteract;
-            @Interact.canceled -= instance.OnInteract;
+            @InteractPC.started -= instance.OnInteractPC;
+            @InteractPC.performed -= instance.OnInteractPC;
+            @InteractPC.canceled -= instance.OnInteractPC;
+            @InteractMobile.started -= instance.OnInteractMobile;
+            @InteractMobile.performed -= instance.OnInteractMobile;
+            @InteractMobile.canceled -= instance.OnInteractMobile;
             @Pause.started -= instance.OnPause;
             @Pause.performed -= instance.OnPause;
             @Pause.canceled -= instance.OnPause;
@@ -838,7 +856,8 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
     {
         void OnMovement(InputAction.CallbackContext context);
         void OnLook(InputAction.CallbackContext context);
-        void OnInteract(InputAction.CallbackContext context);
+        void OnInteractPC(InputAction.CallbackContext context);
+        void OnInteractMobile(InputAction.CallbackContext context);
         void OnPause(InputAction.CallbackContext context);
     }
     public interface IUIActions

--- a/Assets/Data/PlayerControls.inputactions
+++ b/Assets/Data/PlayerControls.inputactions
@@ -24,9 +24,18 @@
                     "initialStateCheck": true
                 },
                 {
-                    "name": "Interact",
+                    "name": "InteractPC",
                     "type": "Button",
                     "id": "10dc3cf2-f27d-4d72-adc9-867f32439735",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "InteractMobile",
+                    "type": "Button",
+                    "id": "8a2ae436-f325-46d1-a95d-49a402ce2fe3",
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "",
@@ -177,23 +186,12 @@
                 },
                 {
                     "name": "",
-                    "id": "65405536-edb3-4d2e-a94c-23ce49a32c39",
-                    "path": "<Touchscreen>/Press",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Mobile",
-                    "action": "Interact",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
                     "id": "2f3024bc-3a42-438f-9980-ccf1d91841c4",
                     "path": "<Mouse>/leftButton",
                     "interactions": "",
                     "processors": "",
                     "groups": "PC",
-                    "action": "Interact",
+                    "action": "InteractPC",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -205,6 +203,17 @@
                     "processors": "",
                     "groups": "PC",
                     "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "65405536-edb3-4d2e-a94c-23ce49a32c39",
+                    "path": "<Touchscreen>/Press",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Mobile",
+                    "action": "InteractMobile",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Prefabs/Temp Pause Menu.prefab
+++ b/Assets/Prefabs/Temp Pause Menu.prefab
@@ -497,7 +497,6 @@ GameObject:
   - component: {fileID: 5662899021801234865}
   - component: {fileID: 5662899021801234866}
   - component: {fileID: 5662899021801234867}
-  - component: {fileID: 5662899021801234868}
   m_Layer: 5
   m_Name: Return Button
   m_TagString: Untagged
@@ -554,8 +553,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300000, guid: 2e5ecc4c5a72b6748ae1383aba770e3c, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -609,30 +608,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: PauseManager, Assembly-CSharp
-        m_MethodName: TempUnpause
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Scrapbook, Assembly-CSharp
-        m_MethodName: Reset
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
         m_MethodName: SetActive
         m_Mode: 6
@@ -644,7 +619,31 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 5662899021801234868}
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: Scrapbook, Assembly-CSharp
+        m_MethodName: Reset
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: PauseManager, Assembly-CSharp
+        m_MethodName: TempUnpause
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: Destroy, Assembly-CSharp
         m_MethodName: DestroyObject
         m_Mode: 1
@@ -656,26 +655,30 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
---- !u!114 &5662899021801234868
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5662899021801234870}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 22f4ad0e350b38143b9b1a08c2c42dff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  objectToDestroy: {fileID: 8090124459325468980}
-  mouseLook: {fileID: 0}
-  clickMovementButton: {fileID: 5662899022040415088}
-  clickMove: 0
-  freeMovementButton: {fileID: 5662899021594590795}
-  freeMove: 0
-  playerController: {fileID: 0}
-  arrowsParent: {fileID: 0}
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: PauseManager, Assembly-CSharp
+        m_MethodName: StartGameUpdate
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: MouseLook, Assembly-CSharp
+        m_MethodName: CheckDeviceTypeOnGameStart
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
 --- !u!1 &5662899022282680728
 GameObject:
   m_ObjectHideFlags: 0
@@ -1345,7 +1348,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.20784314, g: 1, b: 0, a: 1}
+  m_Color: {r: 0.94509804, g: 0.5882353, b: 0.019607844, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -1759,10 +1762,238 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8090124459325468983}
     m_Modifications:
+    - target: {fileID: 2368707097577742322, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -445
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 5662899023016388604}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 6725644671511196720}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_BoolArgument
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742332, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_Type
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097577742332, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 2e5ecc4c5a72b6748ae1383aba770e3c,
+        type: 3}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 5662899023016388604}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 6725644671511196720}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_BoolArgument
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_BoolArgument
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703433, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_Type
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2368707097756703433, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 2e5ecc4c5a72b6748ae1383aba770e3c,
+        type: 3}
     - target: {fileID: 3683861034535030963, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
         type: 3}
       propertyPath: m_Name
       value: MovementOptions
+      objectReference: {fileID: 0}
+    - target: {fileID: 6122318662485734098, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: edf3a12c5d0b11940b49761bb7f13e71,
+        type: 3}
+    - target: {fileID: 6137299543161200051, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_text
+      value: Use the Joystick on the RIGHT to control rotation in both movement modes
       objectReference: {fileID: 0}
     - target: {fileID: 7410526199687392249, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
         type: 3}
@@ -1869,6 +2100,33 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7890421394602149925, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_text
+      value: 'Use the Joystick on the LEFT to control player movement
+
+'
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971096887669077394, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 180.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8441462606875114422, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 8441462606875114422, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -109
+      objectReference: {fileID: 0}
+    - target: {fileID: 9117651327820720642, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -420.00012
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 07d6f9c19cd158b4ab1c673d44348d4a, type: 3}
 --- !u!224 &621079445069287290 stripped
@@ -1877,27 +2135,9 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 7947162457031664771}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &5662899021594590795 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2368707097756703432, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
+--- !u!1 &6725644671511196720 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3683861034535030963, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
     type: 3}
   m_PrefabInstance: {fileID: 7947162457031664771}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &5662899022040415088 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2368707097577742323, guid: 07d6f9c19cd158b4ab1c673d44348d4a,
-    type: 3}
-  m_PrefabInstance: {fileID: 7947162457031664771}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/ThisShouldBeWorking.prefab
+++ b/Assets/Prefabs/ThisShouldBeWorking.prefab
@@ -57,7 +57,7 @@ Camera:
     width: 1
     height: 1
   near clip plane: 0.3
-  far clip plane: 1000
+  far clip plane: 1500
   field of view: 44.959797
   orthographic: 0
   orthographic size: 5
@@ -101,7 +101,7 @@ GameObject:
   - component: {fileID: 6206551848295021829}
   m_Layer: 0
   m_Name: ThisShouldBeWorking
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -113,15 +113,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3110014841751707575}
-  m_LocalRotation: {x: 0, y: 0.90791625, z: 0, w: 0.41915175}
+  m_LocalRotation: {x: 0, y: 0.90791655, z: 0, w: 0.41915098}
   m_LocalPosition: {x: 131.8245, y: 47.487698, z: -36.10384}
-  m_LocalScale: {x: 2.21448, y: 1.2, z: 2.7907019}
+  m_LocalScale: {x: 2.21448, y: 1.64, z: 2.7907019}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6742427750387864985}
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 130.438, z: 0}
 --- !u!33 &3110014841751707571
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -144,7 +144,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Actions: {fileID: -944628639613478452, guid: 282c8a8b4cb4f4e4e8fa399dc312db67,
     type: 3}
-  m_NotificationBehavior: 0
+  m_NotificationBehavior: 2
   m_UIInputModule: {fileID: 0}
   m_DeviceLostEvent:
     m_PersistentCalls:
@@ -155,7 +155,91 @@ MonoBehaviour:
   m_ControlsChangedEvent:
     m_PersistentCalls:
       m_Calls: []
-  m_ActionEvents: []
+  m_ActionEvents:
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: d4268348-12ce-46ac-b20c-f1dfa06a7d7f
+    m_ActionName: Play/Movement[/Keyboard/a,/Keyboard/d,/Keyboard/w,/Keyboard/s]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 4472353e-dceb-480a-8326-eba0895fc76c
+    m_ActionName: Play/Look[/Mouse/position,/Device Simulator Touchscreen/position]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3110014841751707570}
+        m_TargetAssemblyTypeName: PlayerController, Assembly-CSharp
+        m_MethodName: PCPress
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 10dc3cf2-f27d-4d72-adc9-867f32439735
+    m_ActionName: Play/Interact[/Device Simulator Touchscreen/press,/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 66c06c79-90e8-41db-a10a-d1d9714fb505
+    m_ActionName: Play/Pause[/Keyboard/p]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: a25bb5b4-d480-4dc0-b077-f0f0be6b3286
+    m_ActionName: UI/Navigate
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: e6ead1cc-262e-4304-bc1f-a8496e7c6086
+    m_ActionName: UI/Submit
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 45c07fdf-17ed-44b2-b3cd-88d3c3711894
+    m_ActionName: UI/Cancel
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 6edc239d-d2a8-4ca9-8bcd-bece7b10beb1
+    m_ActionName: UI/Point
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 4f55e998-fd72-426e-9f39-006f0eab7cf1
+    m_ActionName: UI/Click[/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: e729952a-90f1-4857-9f70-8f90fa698420
+    m_ActionName: UI/ScrollWheel[/Mouse/scroll]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 319241cc-d687-4af8-b915-88b72eadbae2
+    m_ActionName: UI/MiddleClick[/Mouse/middleButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 07169901-15d5-4a27-bf5d-baf96d516790
+    m_ActionName: UI/RightClick[/Mouse/rightButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: fac0a542-e753-45fc-801f-81489b1559ff
+    m_ActionName: UI/TrackedDevicePosition
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 7d5bb9d2-a05a-4104-a982-4d292960be41
+    m_ActionName: UI/TrackedDeviceOrientation
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3110014841751707570}
+        m_TargetAssemblyTypeName: PlayerController, Assembly-CSharp
+        m_MethodName: MobilePress
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 8a2ae436-f325-46d1-a95d-49a402ce2fe3
+    m_ActionName: Play/InteractMobile[/Device Simulator Touchscreen/press]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: Play
@@ -181,12 +265,12 @@ MonoBehaviour:
   Pause: {fileID: 9159594919121882040, guid: 282c8a8b4cb4f4e4e8fa399dc312db67, type: 3}
   MovementInput: {x: 0, y: 0, z: 0}
   movement: {x: 419.97165, y: 0, z: -46.942738}
-  speed: 700
+  speed: 1400
   CanMove: 1
   clickMove: 0
   mouseLook: {fileID: 3110014841751707582}
   player: {fileID: 3110014841751707575}
-  raycastDistance: 15
+  raycastDistance: 45
   walkingAudio: {fileID: 3177408704368210201}
   movementJoystick: {fileID: 0}
   mobile: 1
@@ -203,12 +287,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   camera: {fileID: 913973731750493800}
-  yrotation: 130.43791
+  yrotation: 180
   mouse_sensitivity: 30
   mouseLocked: 0
   rotationJoystick: {fileID: 0}
   mobile: 1
   mobileLookSpeed: 2.5
+  joystick1: {fileID: 0}
+  joystick2: {fileID: 0}
 --- !u!82 &3177408704368210201
 AudioSource:
   m_ObjectHideFlags: 0
@@ -317,10 +403,10 @@ CharacterController:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Height: 2
+  m_Height: 3
   m_Radius: 0.1
   m_SlopeLimit: 45
-  m_StepOffset: 1
+  m_StepOffset: 6
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
   m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/Manager/PauseManager.cs
+++ b/Assets/Scripts/Manager/PauseManager.cs
@@ -21,12 +21,28 @@ public class PauseManager : MonoBehaviour
     private List<Collectible> collectibles = new List<Collectible>();
     public TextMeshProUGUI textDisplayCount;
     public GameObject joysticks;
+    public bool GameHasStarted;
     private void Start()
     {
         image = PauseMenu.GetComponent<Image>();
         textDisplayStatus.y = collectibles.Count;
         orginalMapColor = image.color;
         orginalSprite = image.sprite;
+    }
+    public void Update()
+    {
+        //Update method runs and checks if escape has been pressed.
+        if (Input.GetKeyDown(KeyCode.Escape) && GameHasStarted)
+        {
+            Pause();
+        }
+    }
+
+    // This method is purely there to stop the play from opening and closing
+    // the pause menu before the game has started.
+    public void StartGameUpdate()
+    {
+        GameHasStarted = true;
     }
     public void Pause()
     {

--- a/Assets/Scripts/MouseLook.cs
+++ b/Assets/Scripts/MouseLook.cs
@@ -18,14 +18,44 @@ public class MouseLook : MonoBehaviour
     public bool mobile = false;
     public float mobileLookSpeed = 2.5f;
 
+    public GameObject joystick1;
+    public GameObject joystick2;
+
     private float xMin = -45, xMax = 45;
 
     void Start()
     {
         mouseLocked = true;
     }
-    
-    
+
+    public void CheckDeviceTypeOnGameStart()
+    {
+        bool isEditor = false;
+#if UNITY_EDITOR
+        /*
+        This piece of code will only run while in the editor. This is because 
+        the simulator mode needs to be checked since if we just check our device
+        it will always return desktop. Only is important for editor.
+         */
+        isEditor = true;
+        if (UnityEngine.Device.SystemInfo.deviceType == DeviceType.Desktop)
+        {
+            joystick1.SetActive(false);
+            joystick2.SetActive(false);
+            Cursor.lockState = CursorLockMode.Locked;
+        }
+#endif
+        // Checks if the device is desktop. If true, disables joystick controls
+        // and locks the mouse to the screen.
+        if (SystemInfo.deviceType == DeviceType.Desktop && !isEditor)
+        {
+            joystick1.SetActive(false);
+            joystick2.SetActive(false);
+            Cursor.lockState = CursorLockMode.Locked;
+        }
+
+    }
+
     // Update is called once per frame
     void Update()
     {
@@ -34,14 +64,37 @@ public class MouseLook : MonoBehaviour
         ////pos.y += camera_y;
         //transform.rotation = pos;
         //Get mouse movement in new input system
-        if (!mouseLocked && !mobile)
+
+
+        bool isEditor = false;
+#if UNITY_EDITOR
+        /*
+        This piece of code will only run while in the editor. This is because 
+        the simulator mode needs to be checked since if we just check our device
+        it will always return desktop. Only is important for editor.
+        */
+        isEditor = true;
+        if (UnityEngine.Device.SystemInfo.deviceType == DeviceType.Desktop && !mouseLocked)
         {
-            mousemovement = Mouse.current.delta.ReadValue();     
+            mousemovement = Mouse.current.delta.ReadValue();
         }
-        else if (!mouseLocked && mobile)
+        if (UnityEngine.Device.SystemInfo.deviceType == DeviceType.Handheld && !mouseLocked)
         {
             mousemovement = rotationJoystick.Direction * mobileLookSpeed;
         }
+#endif
+
+        //Runs when device is desktop
+        if (SystemInfo.deviceType == DeviceType.Desktop && !mouseLocked && !isEditor)
+        {
+            mousemovement = Mouse.current.delta.ReadValue();
+        }
+        //Runs when device is mobile
+        if (SystemInfo.deviceType == DeviceType.Handheld && !mouseLocked && !isEditor)
+        {
+            mousemovement = rotationJoystick.Direction * mobileLookSpeed;
+        }
+
 
         xrotation -= mousemovement.y * Time.deltaTime * mouse_sensitivity;
         xrotation = Mathf.Clamp(xrotation, xMin, xMax);
@@ -53,5 +106,5 @@ public class MouseLook : MonoBehaviour
         gameObject.transform.rotation = Quaternion.Euler(0, yrotation, 0);
 
     }
-    
+
 }


### PR DESCRIPTION
So there is alot going on here and ill try to explain it.

first raycast.

![image](https://github.com/JadenCooper/BogBuddiesToilets/assets/78123942/746b8498-1e38-4aa0-878b-1bbb1c0a16aa)
Raycast is split into 3 methods now. 2 of them are now methods that seperate mobile and pc press. This is done through the new input system using events. The raycasthitinteractable method is just repeated code that was in both methods. 

You can check on what the events are by clicking the player game object in the scene and going to the player input, then clicking events then clicking play. seen below vv
![image](https://github.com/JadenCooper/BogBuddiesToilets/assets/78123942/9ee97e1f-3441-4c9c-8fff-9b8bdd7dee1f)

and yes I also changed the input system a little bit. I only Seperated the Touch and Click inputs to different areas to hopefully avoid anything breaking in the process.
![image](https://github.com/JadenCooper/BogBuddiesToilets/assets/78123942/e424f98f-fa5e-4447-9a99-499b7a974c82)

That is all the raycast changes. 

Next is the movement controls. and hopefully this makes sense.

Basically there is a way to check what the type of device you are running. Therefore I added a bunch of checks to see if the device is mobile (handheld is what unity calls it) or pc (desktop is what unity calls it). Then for each one of these checks there is also a check above it to see if we are in the unity editor or not.

If we are in the unity editor, it will always return PC, since its not checking if we are in simulator or not, its purely checking the actual device settings on how PC. Therefore I found another way around this with a command that will only run while we are in the editor. It prevents the other code from running and focuses on itself. Though you will soon see that both pieces of code are the excate same, except 1 is checking the unityeditor and one is checking the system its on. 

Here is what it looks like in the code:
![image](https://github.com/JadenCooper/BogBuddiesToilets/assets/78123942/722cdd14-a231-4fe1-bf82-4665684c72f8)

There is currently 3 instances of this...
1. MouseLook.cs script
![image](https://github.com/JadenCooper/BogBuddiesToilets/assets/78123942/69a455bd-15c8-4353-90c1-d72ae90f73d9)
2. MouseLook.cs script
![image](https://github.com/JadenCooper/BogBuddiesToilets/assets/78123942/8ef46418-87c9-4ff8-b001-f4c4c78cb7f5)
3. PlayerController.cs script
![image](https://github.com/JadenCooper/BogBuddiesToilets/assets/78123942/32fbf32e-b7d6-4ce8-a552-b7301e28c0d4)

I have also made ESC the key to open the pause menu while in pc controls. which follows the same local as the pause menu.

You might notice that the mouse is not locked when you unpause, that is because you have to click back on the scene for it to relock. it should automatically do this in the live build. I am fairly sure this is a editor bug, and not a live bug.

This also should fig the raycast breaking bug. But please don't quote me on that..... I havnt been able to replicate it.

and yeah please let me know if something is broken.